### PR TITLE
Write non-numeric values in quotes

### DIFF
--- a/nagios_exporter.py
+++ b/nagios_exporter.py
@@ -342,7 +342,7 @@ def convert_value_to_base_unit(value, unit):
         value = float(value)
         value *= UNIT_TO_SCALE[unit]
     except ValueError:
-        # Leave value as a string. e.g. 0.3.1
+        # Leave value as-is to be handled by format_metric().
         return value + unit
     return str(value)
 
@@ -375,6 +375,10 @@ def format_labels(labels):
 
 def format_metric(name, labels, value):
     """Formats the prometheus metric."""
+    try:
+        float(value)
+    except ValueError:
+        value = '"%s"' % value
     return 'nagios_%s%s %s' % (
         name.replace('-', '_'), format_labels(labels), value)
 

--- a/nagios_exporter_test.py
+++ b/nagios_exporter_test.py
@@ -165,6 +165,20 @@ class NagiosExporterTest(unittest.TestCase):
 
         self.assertIn('nagios_livestatus_available 0', lines)
 
+    def test_format_metric_with_various_value_types(self):
+      # Integer.
+      self.assertEqual(
+          'nagios_check_cmd{key="/"} 1',
+          nagios_exporter.format_metric('check_cmd', {'key': '/'}, '1'))
+      # Float.
+      self.assertEqual(
+          'nagios_check_cmd{key="/"} 0.1',
+          nagios_exporter.format_metric('check_cmd', {'key': '/'}, '0.1'))
+      # String.
+      self.assertEqual(
+          'nagios_check_cmd{key="/"} "v0.1"',
+          nagios_exporter.format_metric('check_cmd', {'key': '/'}, 'v0.1'))
+
     @mock.patch.object(nagios_exporter, 'collect_metrics')
     def test_metrics_when_exception_is_raised(self, mock_metrics):
         mock_metrics.side_effect = nagios_exporter.NagiosResponseError('error')


### PR DESCRIPTION
Prometheus attempts to read unquoted values as floats. If it fails then Prometheus stops processing subsequent metrics.

This PR wraps non-numeric values in quotes, which Prometheus handles correctly as strings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-nagios-exporter/6)
<!-- Reviewable:end -->
