### PR TITLE
Properly handle string values as labels

### DIFF
--- a/nagios_exporter.py
+++ b/nagios_exporter.py
@@ -378,7 +378,11 @@ def format_metric(name, labels, value):
     try:
         float(value)
     except ValueError:
-        value = '"%s"' % value
+        # Convert the value (which is not a number) to a label. And use a
+        # constant value of 1 instead.
+        labels = labels.copy()
+        labels['value'] = value
+        value = 1
     return 'nagios_%s%s %s' % (
         name.replace('-', '_'), format_labels(labels), value)
 
@@ -391,7 +395,7 @@ def get_status(session):
 
     lines = []
     for key, value in values.iteritems():
-        lines.append(format_metric(key, '', value))
+        lines.append(format_metric(key, {}, value))
 
     return lines
 

--- a/nagios_exporter_test.py
+++ b/nagios_exporter_test.py
@@ -176,7 +176,7 @@ class NagiosExporterTest(unittest.TestCase):
           nagios_exporter.format_metric('check_cmd', {'key': '/'}, '0.1'))
       # String.
       self.assertEqual(
-          'nagios_check_cmd{key="/"} "v0.1"',
+          'nagios_check_cmd{value="v0.1", key="/"} 1',
           nagios_exporter.format_metric('check_cmd', {'key': '/'}, 'v0.1'))
 
     @mock.patch.object(nagios_exporter, 'collect_metrics')


### PR DESCRIPTION
I would have sworn that Prometheus allowed string values. I would have been wrong.

This PR properly avoids ever publishing a value that is not numeric. To handle string values from nagios, a new label is added at the time of formatting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-nagios-exporter/7)
<!-- Reviewable:end -->
