### PR TITLE
Whitelist all Nagios checks that mlab-ns relies on.

### DIFF
--- a/prometheus-nagios-exporter.service
+++ b/prometheus-nagios-exporter.service
@@ -2,7 +2,22 @@
 Description=Prometheus Nagios Exporter Service
 
 [Service]
-ExecStart=/opt/mlab/prometheus-nagios-exporter/nagios_exporter.py --path /var/lib/nagios3/rw/live --perf_data "--data_names=check_disk_boot=used;;;;total" --whitelist nagios_check_vdlimit_iupui_ndt_perf_data --whitelist nagios_check_disk_boot_perf_data_total --whitelist nagios_check_disk_boot_perf_data_used --whitelist nagios_check_ndt_e2e_state
+ExecStart=/opt/mlab/prometheus-nagios-exporter/nagios_exporter.py \
+    --path /var/lib/nagios3/rw/live \
+    --perf_data "--data_names=check_disk_boot=used;;;;total" \
+    --whitelist nagios_check_disk_boot_perf_data_total \
+    --whitelist nagios_check_disk_boot_perf_data_used \
+    --whitelist nagios_check_vdlimit_iupui_ndt_perf_data \
+    --whitelist nagios_check_ndt_state \
+    --whitelist nagios_check_ndt_ssl_state \
+        --whitelist nagios_check_vdlimit_iupui_ndt_state \
+        --whitelist nagios_check_lame_duck_iupui_ndt_state \
+        --whitelist nagios_check_ndt_e2e_state \
+        --whitelist nagios_check_tcp_state \
+        --whitelist nagios_check_http_state \
+    --whitelist nagios_check_mobiperf_state \
+    --whitelist nagios_check_neubot_state
+
 StandardOutput=null
 
 [Install]


### PR DESCRIPTION
 As we continue to prepare to migrate mlab-ns off of Nagios and onto Prometheus, we would like to be able to create Grafana dashboards and panels that compare how Nagios sees the platform compared to how Prometheus sees the platform. 

Note: nagios_exporter apparently takes service *checks* as whitelist filters, not service *names*. What this means is that we have to whitelist, for example, the `check_tcp` check, one of which will be the service `ndt_tcp`. The same for `check_http`. This exposes a few more things that we might otherwise want, but not so much as to be prohibitive.

Also format the `ExecStart` command for better readability.