### PR TITLE
Parse raw_values more carefully

### DIFF
--- a/nagios_exporter.py
+++ b/nagios_exporter.py
@@ -243,8 +243,11 @@ def parse_perf_data_fields(raw_perf_data):
     """
     fields = {}
     for raw_value in raw_perf_data:
-        name, values = raw_value.split('=')
-        values = values.split(';')
+        values = raw_value.split('=')
+        if len(values) <= 1:
+            continue
+        name = values[0]
+        values = values[1].split(';')
         fields[name] = values
     return fields
 

--- a/nagios_exporter_test.py
+++ b/nagios_exporter_test.py
@@ -314,6 +314,13 @@ class NagiosExporterTest(unittest.TestCase):
 
         self.assertItemsEqual(actual, expected)
 
+    def test_parse_perf_data_fields_with_good_values(self):
+        self.assertItemsEqual(
+                {'/': ['2400MB', '48356', '54400', '0', '60445']},
+                nagios_exporter.parse_perf_data_fields(
+                    ['/=2400MB;48356;54400;0;60445']))
+    def test_parse_perf_data_fields_with_bad_values(self):
+        self.assertItemsEqual({}, nagios_exporter.parse_perf_data_fields(['-6]']))
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
This PR fixes a bug found in production where the perf data raw values were corrupted and the split on "=" was failing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-nagios-exporter/19)
<!-- Reviewable:end -->
