### PR TITLE
Use python executable from PATH

### DIFF
--- a/nagios_exporter.py
+++ b/nagios_exporter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """nagios_exporter.py reports Nagios service status for Prometheus collection.
 
 The default mode for nagios_exporter.py is to start an HTTP server that


### PR DESCRIPTION
Path to `python` could be anything, e.g. `/usr/local/bin/python` if you weren't using the system package manager, or `/opt/python/bin/python` if you compiled it yourself. `/usr/bin/env` is more reliable and also works on other Unix-compatible operating systems such as FreeBSD.