### PR TITLE
also replace . with _ in check labels

### DIFF
--- a/nagios_exporter.py
+++ b/nagios_exporter.py
@@ -397,7 +397,7 @@ def format_metric(name, labels, value):
         labels['value'] = value
         value = 1
     return 'nagios_%s%s %s' % (
-        name.replace('-', '_'), format_labels(labels), value)
+        name.replace('-', '_').replace('.', '_'), format_labels(labels), value)
 
 
 def get_status(session):


### PR DESCRIPTION
...without this I could only use the metrics from Livestatus itself - Prometheus barfed on everything else as the label names included a dot ('.'). It seemed odd to me, but here's the change that allowed me to import/query data for all the hosts I'm monitoring.