### PR TITLE
replace dot in metric names with underscore

### DIFF
--- a/nagios_exporter.py
+++ b/nagios_exporter.py
@@ -397,7 +397,7 @@ def format_metric(name, labels, value):
         labels['value'] = value
         value = 1
     return 'nagios_%s%s %s' % (
-        name.replace('-', '_'), format_labels(labels), value)
+        name.replace('-', '_').replace('.','_'), format_labels(labels), value)
 
 
 def get_status(session):


### PR DESCRIPTION
Some metrics collect by check_mk agent plugins include a dot in their name (e.g. mem.linux and cpu.loads). Those dots need to be replaced by underscores so that Prometheus can parse the metrics without error.